### PR TITLE
feat: add Tavily as opt-in parallel web search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository is the **single-clone distribution** of the entire [Yogsoth AI](
 - 🔬 **Convergence & synthesis** — multi-criteria scoring, Pareto frontier construction, pairwise ranking, structured consensus, dialectical synthesis across competing threads
 - 📏 **Executable Research Specs** — machine-readable documents with checkbox progress tracking, quantified completion criteria, backtrack conditions, and session recovery. Another CC instance picks up where you left off
 - 🧪 **Experiment design** — full experimental methodology generation (factor-level design, parameter screening, sensitivity analysis) ready for execution
-- 🌐 **5 MCP integrations** — Semantic Scholar, Brave Search, AlphaXiv, Apify web scraping, and Wiki Vault for persistent knowledge graphs
+- 🌐 **6 MCP integrations** — Semantic Scholar, Brave Search, Tavily, AlphaXiv, Apify web scraping, and Wiki Vault for persistent knowledge graphs
 
 ---
 
@@ -187,8 +187,8 @@ Below the orchestrator, all 800+ skills are organized into exactly four layers. 
 │  hypothesis-formulation · analogy-extraction · pairwise-comparison     │
 │  assumption-audit · falsifiability-check · monte-carlo-sampling · ...  │
 ├────────────────────────────────────────────────────────────────────────┤
-│  MCP LAYER (5 servers — external tool access)                          │
-│  semantic-scholar · brave-search · alphaxiv · apify · wiki-vault       │
+│  MCP LAYER (6 servers — external tool access)                          │
+│  semantic-scholar · brave-search · tavily · alphaxiv · apify · wiki-vault │
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -245,6 +245,7 @@ de-anthropocentric-research-engine/
 | **semantic-scholar** | [`@yogsoth-ai/semantic-scholar-mcp`](https://github.com/yogsoth-ai/semantic-scholar-mcp) | stdio | Paper lookup, citations, references, recommendations, author info (8 tools) |
 | **wiki-vault** | [`@yogsoth-ai/wiki-vault`](https://github.com/yogsoth-ai/wiki-vault) | stdio | Research knowledge graph — BM25 search, typed edges, graph traversal (8 tools) |
 | **brave-search** | `@brave/brave-search-mcp-server` | stdio | Web search, news search, local search, LLM context |
+| **tavily-search** | `tavily-mcp` | stdio | Web search optimized for LLMs (opt-in alternative to Brave Search) |
 | **apify** | `@apify/actors-mcp-server` | stdio | Web scraping via RAG web browser, Google Scholar |
 | **alphaxiv** | — | http | arXiv paper search, Q&A, PDF queries, code exploration |
 
@@ -354,6 +355,12 @@ You: /executing-specs docs/de-anthropocentric/specs/2026-05-19-cot-faithfulness-
 | Variable | Description |
 |----------|-------------|
 | `BRAVE_API_KEY` | [Brave Search API key](https://brave.com/search/api/) |
+
+#### tavily-search (`tavily-mcp`) *(optional)*
+
+| Variable | Description |
+|----------|-------------|
+| `TAVILY_API_KEY` | [Tavily API key](https://app.tavily.com) — opt-in alternative to Brave Search for web search (1,000 free credits/month) |
 
 #### apify (`@apify/actors-mcp-server`)
 

--- a/mcp.example.json
+++ b/mcp.example.json
@@ -19,6 +19,14 @@
         "BRAVE_API_KEY": "<your-brave-api-key>"
       }
     },
+    "tavily-search": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp@latest"],
+      "env": {
+        "TAVILY_API_KEY": "<your-tavily-api-key>"
+      }
+    },
     "wiki-vault": {
       "type": "stdio",
       "command": "npx",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@apify/actors-mcp-server": "^0.10.4",
     "@brave/brave-search-mcp-server": "^2.0.82",
+    "tavily-mcp": "^0.1.4",
     "@yogsoth-ai/semantic-scholar-mcp": "^1.0.0",
     "@yogsoth-ai/wiki-vault": "^1.2.1"
   }

--- a/skills/broad-web-search/SKILL.md
+++ b/skills/broad-web-search/SKILL.md
@@ -13,9 +13,14 @@ Quick web scanning for landscape understanding.
 
 Import — strictly follow `web-browsing/web-search` skill protocol.
 
+## Provider Selection
+
+- If the `tavily-search` MCP server is configured and active, use `tavily_search` (with `max_results=10`) as the search provider.
+- Otherwise, fall back to `brave_web_search` (with `count=10`).
+
 ## Hard Constraints
 
-- Set `count=10` on every `brave_web_search` call
+- Set `count=10` (Brave) or `max_results=10` (Tavily) on every search call
 - Execute multiple calls with varied queries
 - Do not complete this SOP until at least 150 total search results have been gathered
 - This ensures broad coverage, not just the first page of one query

--- a/skills/web-search/SKILL.md
+++ b/skills/web-search/SKILL.md
@@ -17,9 +17,14 @@ Import — strictly follow `web-browsing/web-search` skill protocol.
 
 Snippets only — do not draw conclusions from search result snippets alone. Snippets provide leads for deeper investigation (web-research or paper-search).
 
+## Provider Selection
+
+- If the `tavily-search` MCP server is configured and active, use `tavily_search` (with `max_results=10`) as the search provider.
+- Otherwise, fall back to `brave_web_search` (with `count=10`).
+
 ## Budget
 
-Quantity target is set by the calling strategy's budget table. This SOP executes one unit = one brave_web_search call (count=10 results).
+Quantity target is set by the calling strategy's budget table. This SOP executes one unit = one search call (count=10 results).
 
 ## Import Source
 


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable alternative web search provider alongside the existing Brave Search integration. This is an **additive** migration — Brave Search remains fully functional and is the default; Tavily is opt-in for users who configure `TAVILY_API_KEY`.

## Changes

### Dependencies
- Added `tavily-mcp` (`^0.1.4`) to `package.json`

### MCP Configuration
- Added `tavily-search` stdio MCP server entry in `mcp.example.json` with `TAVILY_API_KEY` env var
- Existing `brave-search` entry is unchanged

### Documentation (`README.md`)
- Updated MCP integration count from 5 to 6
- Added Tavily row to MCP Servers table
- Added Tavily to the architecture MCP layer diagram
- Added `TAVILY_API_KEY` env var documentation section

### Skills
- `skills/web-search/SKILL.md` — Added provider-selection clause: prefer `tavily_search` if the Tavily MCP server is active, else use `brave_web_search`
- `skills/broad-web-search/SKILL.md` — Same provider-selection clause, updated hard constraints to reference both providers' parameter names

## Files Changed
- `package.json`
- `mcp.example.json`
- `README.md`
- `skills/web-search/SKILL.md`
- `skills/broad-web-search/SKILL.md`

## Environment Variable Changes
- Added `TAVILY_API_KEY` — Tavily API key (opt-in, get free key at https://app.tavily.com)
- Existing `BRAVE_API_KEY` is unchanged

## Notes for Reviewers
- ~45 additional skill files reference `brave_web_search` directly. These are intentionally left unchanged under the additive strategy — they continue to work with Brave Search. The two canonical web-search SOPs now handle provider selection, which covers the primary entry points.
- JSON validity of `package.json` and `mcp.example.json` verified.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration correctly adds Tavily as an opt-in parallel web search provider alongside Brave Search. All five reported files are modified appropriately: package.json gains the `tavily-mcp` dependency, mcp.example.json gains a well-formed server config block, README.md updates counts and documentation, and both skill files gain provider-selection clauses with proper fallback logic. The implementation is purely additive — Brave Search is fully preserved. One minor inconsistency: the frontmatter `description` field of `broad-web-search/SKILL.md` still hard-references `brave_web_search count=10` while the body now supports both providers.
