### PR TITLE
Add Keenable as a keyless web-search MCP integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository is the **single-clone distribution** of the entire [Yogsoth AI](
 - 🔬 **Convergence & synthesis** — multi-criteria scoring, Pareto frontier construction, pairwise ranking, structured consensus, dialectical synthesis across competing threads
 - 📏 **Executable Research Specs** — machine-readable documents with checkbox progress tracking, quantified completion criteria, backtrack conditions, and session recovery. Another CC instance picks up where you left off
 - 🧪 **Experiment design** — full experimental methodology generation (factor-level design, parameter screening, sensitivity analysis) ready for execution
-- 🌐 **6 MCP integrations** — Semantic Scholar, Brave Search, Tavily, AlphaXiv, Apify web scraping, and Wiki Vault for persistent knowledge graphs
+- 🌐 **7 MCP integrations** — Semantic Scholar, Brave Search, Tavily, Keenable, AlphaXiv, Apify web scraping, and Wiki Vault for persistent knowledge graphs
 
 ---
 
@@ -188,8 +188,8 @@ Inside every package, the skills are organized into exactly four layers. The rul
 │  hypothesis-formulation · analogy-extraction · pairwise-comparison        │
 │  assumption-audit · falsifiability-check · monte-carlo-sampling · ...     │
 ├───────────────────────────────────────────────────────────────────────────┤
-│  MCP LAYER (6 servers — external tool access)                             │
-│  semantic-scholar · brave-search · tavily · alphaxiv · apify · wiki-vault │
+│  MCP LAYER (7 servers — external tool access)                             │
+│  semantic-scholar · brave · tavily · keenable · alphaxiv · apify · wiki   │
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -257,6 +257,7 @@ de-anthropocentric-research-engine/
 | **wiki-vault** | [`@yogsoth-ai/wiki-vault`](https://github.com/yogsoth-ai/wiki-vault) | stdio | Research knowledge graph — BM25 search, typed edges, graph traversal (8 tools) |
 | **brave-search** | `@brave/brave-search-mcp-server` | stdio | Web search, news search, local search, LLM context |
 | **tavily-search** | `tavily-mcp` | stdio | Web search optimized for LLMs (opt-in alternative to Brave Search) |
+| **keenable** | — | http | Web search + page fetch, keyless by default (no API key; hosted remote server) |
 | **apify** | `@apify/actors-mcp-server` | stdio | Web scraping via RAG web browser, Google Scholar |
 | **alphaxiv** | — | http | arXiv paper search, Q&A, PDF queries, code exploration |
 
@@ -442,6 +443,10 @@ You: /executing-specs docs/de-anthropocentric/specs/2026-05-19-cot-faithfulness-
 | Variable | Description |
 | -------- | ----------- |
 | `TAVILY_API_KEY` | [Tavily API key](https://app.tavily.com) — opt-in alternative to Brave Search for web search (1,000 free credits/month) |
+
+#### keenable (HTTP — no local install)
+
+No configuration needed. Connects directly to `https://api.keenable.ai/mcp` and is **keyless by default** (public endpoint, rate-limited). Setting an optional `KEENABLE_API_KEY` only lifts the rate limit; it is never required. Provides web search plus page fetch (clean markdown).
 
 #### apify (`@apify/actors-mcp-server`)
 

--- a/mcp.example.json
+++ b/mcp.example.json
@@ -27,6 +27,10 @@
         "TAVILY_API_KEY": "<your-tavily-api-key>"
       }
     },
+    "keenable": {
+      "type": "http",
+      "url": "https://api.keenable.ai/mcp"
+    },
     "wiki-vault": {
       "type": "stdio",
       "command": "npx",

--- a/skills/web-search/SKILL.md
+++ b/skills/web-search/SKILL.md
@@ -44,6 +44,7 @@ equally valid.
 
 - Brave — see Provider Details § Brave
 - Tavily — see Provider Details § Tavily
+- Keenable — see Provider Details § Keenable (keyless; no API key required)
 
 Set the result count to ~10 per call (provider-specific parameter named in
 each Provider Details subsection).
@@ -167,6 +168,37 @@ tavily_search(query="Claude 3.5 Sonnet release date", max_results=5)
 Landscape scan:
 ```
 tavily_search(query="MCP server frameworks comparison 2025", max_results=10)
+```
+
+### Keenable
+
+Keyless by default — the `keenable` MCP server needs no API key.
+
+**Available tools:**
+
+| Tool | Purpose | Returns |
+|------|---------|---------|
+| `search_web_pages` | Web search over the Keenable index | title, URL, description snippet |
+| `fetch_page_content` | Fetch a URL as clean markdown | title, URL, full page content |
+
+**Key parameters:**
+
+- `search_web_pages`:
+  - `query` (required): search terms
+- `fetch_page_content`:
+  - `url` (required): page to fetch as markdown
+
+**Examples:**
+
+Quick fact check:
+```
+search_web_pages(query="Claude 3.5 Sonnet release date")
+```
+
+Landscape scan then deep read:
+```
+search_web_pages(query="MCP server frameworks comparison 2025")
+fetch_page_content(url="https://...")
 ```
 
 <!-- BEGIN available-tables (generated) -->


### PR DESCRIPTION
Adds [Keenable](https://keenable.ai) as a 7th MCP server, alongside Tavily and Brave.

Keenable is a **hosted remote (HTTP) MCP server**, so unlike the npx-based providers it needs no local install and no API key: it is **keyless by default** (public endpoint, rate-limited to 1,000 req/hour). An optional `KEENABLE_API_KEY` only lifts the rate limit; it is never required. On top of web search it exposes page fetch (`fetch_page_content`) returning clean markdown.

Changes:
- `mcp.example.json` — `keenable` HTTP server entry (no env, mirrors the `alphaxiv` remote entry)
- `README.md` — integration count, MCP-layer diagram, server table, env docs
- `skills/web-search/SKILL.md` — provider selection + Keenable provider details (`search_web_pages` + `fetch_page_content`)

No `package.json` change — a remote server has no npm package to install.

Verified: `mcp.example.json` is valid JSON, the ASCII diagram stays aligned, and the Keenable endpoint was self-tested live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)